### PR TITLE
ルーティング整理：currentDateをクエリパラメータに変更

### DIFF
--- a/app/Calendar/CalendarMonthView.php
+++ b/app/Calendar/CalendarMonthView.php
@@ -115,8 +115,8 @@ class CalendarMonthView extends CalendarView {
 
         // データ
         // スケジュールを読み込んでおく
-        $firstDate = $this->carbon->startOfMonth()->startOfWeek()->format('Y-m-d'); // カレンダー表示範囲の初日
-        $lastDate = $this->carbon->lastOfMonth()->endOfWeek()->format('Y-m-d'); // カレンダー表示範囲の最終日
+        $firstDate = $this->carbon->copy()->startOfMonth()->startOfWeek()->toDateString(); // カレンダー表示範囲の初日
+        $lastDate = $this->carbon->copy()->lastOfMonth()->endOfWeek()->toDateString(); // カレンダー表示範囲の最終日
         $monthlySchedules = $this->getGroupedSchedulesByDateRange([
             'start' => $firstDate,
             'end' => $lastDate,

--- a/app/Calendar/CalendarView.php
+++ b/app/Calendar/CalendarView.php
@@ -136,8 +136,10 @@ abstract class CalendarView {
     function getScheduleAddButton($day):string
     {
         $userId = Request::query('userId', Auth::id());
+        $currentDate = Request::query('currentDate', now()->toDateString());
 
-        $scheduleAddBtnRoute = route('schedule.create', ['date' => $day->getString('Y-m-d')]) . '?' . http_build_query(['userId' => $userId]);
+        $scheduleAddBtnRoute = route('schedule.create') . '?' . http_build_query(compact('userId', 'currentDate'));
+
         $html[] = trim('
             <div class="schedule-add-button-block">
                 <a class="schedule-add-button" href="' . $scheduleAddBtnRoute .'">

--- a/app/Calendar/CalendarView.php
+++ b/app/Calendar/CalendarView.php
@@ -39,61 +39,73 @@ abstract class CalendarView {
     /**
     * 前日の日付をY-m-d形式で取得するメソッド
     *
+    * @param string $date 日付 Y-m-d ※省略で現在
+    *
     * @return string 前の日（例：2025-06-15）
     */
-    function getBeforeDay(): string
+    static function getBeforeDay($date = null): string
     {
-        return $this->carbon->copy()->subDay()->format('Y-m-d');
+        return Carbon::parse($date ?? now())->subDay()->toDateString();
     }
 
     /**
     * 翌日の日付をY-m-d形式で取得するメソッド
     *
+    * @param string $date 日付 Y-m-d ※省略で現在
+    *
     * @return string 次の日（例：2025-06-17）
     */
-    function getNextDay(): string
+    static function getNextDay($date = null): string
     {
-        return $this->carbon->copy()->addDay()->format('Y-m-d');
+        return Carbon::parse($date ?? now())->addDay()->toDateString();
     }
 
     /**
     * 1週間前の日付をY-m-d形式で取得するメソッド
     *
+    * @param string $date 日付 Y-m-d ※省略で現在
+    *
     * @return string 前の週（例：2025-06-09）
     */
-    function getBeforeWeek(): string
+    static function getBeforeWeek($date = null): string
     {
-        return $this->carbon->copy()->subWeek()->format('Y-m-d');
+        return Carbon::parse($date ?? now())->subWeek()->toDateString();
     }
     
     /**
     * 1週間後の日付をY-m-d形式で取得するメソッド
     *
+    * @param string $date 日付 Y-m-d ※省略で現在
+    *
     * @return string 次の週（例：2025-06-23）
     */
-    function getNextWeek(): string
+    static function getNextWeek($date = null): string
     {
-        return $this->carbon->copy()->addWeek()->format('Y-m-d');
+        return Carbon::parse($date ?? now())->addWeek()->toDateString();
     }
 
     /**
     * 前の月の1日をY-m-d形式で取得するメソッド
     *
+    * @param string $date 日付 Y-m-d ※省略で現在
+    *
     * @return string 前の月（例：2025-05-01）
     */
-    function getBeforeMonth(): string
+    static function getBeforeMonth($date = null): string
     {
-        return $this->carbon->copy()->startOfMonth()->subMonth()->format('Y-m-d');
+        return Carbon::parse($date ?? now())->startOfMonth()->subMonth()->toDateString();
     }
     
     /**
     * 次の月の1日Y-m-d形式で取得するメソッド
     *
+    * @param string $date 日付 Y-m-d ※省略で現在
+    *
     * @return string 次の月（例：2025-07-01）
     */
-    function getNextMonth(): string
+    static function getNextMonth($date = null): string
     {
-        return $this->carbon->copy()->startOfMonth()->addMonth()->format('Y-m-d');
+        return Carbon::parse($date ?? now())->startOfMonth()->addMonth()->toDateString();
     }
 
     /**

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -16,6 +16,7 @@ class CalendarController extends Controller
     function show(Request $request, $type = 'month', $currentDate = null):View
     {
         $userId = $request->query('userId', Auth::id());
+        $currentDate = $request->query('currentDate', Carbon::now()->format('Y-m-d'));
 
         $allUsers = User::all();
 

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -13,7 +13,7 @@ use Illuminate\View\View;
 
 class CalendarController extends Controller
 {
-    function show(Request $request, $type = 'month', $currentDate = null):View
+    function show(Request $request, $type = 'month'):View
     {
         $userId = $request->query('userId', Auth::id());
         $currentDate = $request->query('currentDate', Carbon::now()->format('Y-m-d'));

--- a/app/Http/Controllers/ScheduleController.php
+++ b/app/Http/Controllers/ScheduleController.php
@@ -32,13 +32,13 @@ class ScheduleController extends Controller
         return view('schedule.scheduleShow', ['id' => $id]);
     }
 
-    function create($date = null):view
+    function create():view
     {
         $contents = $this->getCommonContents();
 
         $contents['userId'] = FacadesRequest::query('userId', null);
         $contents['mode'] = 'create';
-        $contents['date'] = $date ?? '';
+        $contents['currentDate'] = FacadesRequest::query('currentDate', null);
 
         return view('schedule.scheduleEdit', $contents);
     }

--- a/resources/views/calendar/calendar.blade.php
+++ b/resources/views/calendar/calendar.blade.php
@@ -18,7 +18,7 @@
                                         @if($type === $viewType)
                                             <span class="calendar-changeView-active">{{ $label }}</span>
                                         @else
-                                            <a href="{{ route('calendar.view', ['type' => $viewType, 'currentDate' => $currentDate] ) . '?' . http_build_query(['userId' => $userId]) }}">{{ $label }}</a>
+                                            <a href="{{ route('calendar.view', ['type' => $viewType] ) . '?' . http_build_query(['userId' => $userId, 'currentDate' => $currentDate]) }}">{{ $label }}</a>
                                         @endif
                                     </div>
                                 @endforeach

--- a/resources/views/calendar/date_block.blade.php
+++ b/resources/views/calendar/date_block.blade.php
@@ -1,33 +1,46 @@
 <div class="calendar-date-block">
     @php
-        $queryParam = '?' . http_build_query(['userId' => $userId]);
+        $baseQueryParams = ['userId' => $userId];
+        $getQueryParam = fn($addingParam = []) => '?' . http_build_query([...$baseQueryParams, ...$addingParam]);
     @endphp
     <span>
-        <a class="calendar-move-button" href="{{ route('calendar.view', ['type' => $type, 'currentDate' => $calendar->getBeforeWeek()]) . $queryParam }}">
+        <a
+            class="calendar-move-button"
+            href="{{ route('calendar.view', ['type' => $type]) . $getQueryParam(['currentDate' => $type ==='month' ? \App\Calendar\CalendarView::getBeforeMonth($currentDate) : \App\Calendar\CalendarView::getBeforeWeek($currentDate)]) }}"
+        >
             <span class="material-symbols-outlined">keyboard_double_arrow_left</span>
         </a>
     </span>
     @if ($type !== 'month')
     <span>
-        <a class="calendar-move-button" href="{{ route('calendar.view', ['type' => $type, 'currentDate' => $calendar->getBeforeDay()]) . $queryParam }}">
+        <a
+            class="calendar-move-button"
+            href="{{ route('calendar.view', ['type' => $type]) . $getQueryParam(['currentDate' => \App\Calendar\CalendarView::getBeforeDay($currentDate)]) }}"
+        >
             <span class="material-symbols-outlined">keyboard_arrow_left</span>
         </a>
     </span>
     @endif
     <span class="calendar-date">
-        <a href="{{ route('calendar.view', ['type' => $type, 'currentDate' => \Carbon\Carbon::now()->format('Y-m-d') ]) . $queryParam }}">
+        <a href="{{ route('calendar.view', ['type' => $type]) . $getQueryParam(['currentDate' => now()->toDateString('Y-m-d')]) }}">
             {{ $type === 'month' ? $calendar->getTitle() : $calendar->getCurrentDayString() }}
         </a>
     </span>
     @if ($type !== 'month')
     <span>
-        <a class="calendar-move-button" href="{{ route('calendar.view', ['type' => $type, 'currentDate' => $calendar->getNextDay()]) . $queryParam }}">
+        <a
+            class="calendar-move-button"
+            href="{{ route('calendar.view', ['type' => $type]) . $getQueryParam(['currentDate' => \App\Calendar\CalendarView::getNextDay($currentDate)]) }}"
+        >
             <span class="material-symbols-outlined">keyboard_arrow_right</span>
         </a>
     </span>
     @endif
     <span>
-        <a class="calendar-move-button" href="{{ route('calendar.view', ['type' => $type, 'currentDate' => $calendar->getNextWeek()]) . $queryParam }}">
+        <a
+            class="calendar-move-button"
+            href="{{ route('calendar.view', ['type' => $type]) . $getQueryParam(['currentDate' => $type ==='month' ? \App\Calendar\CalendarView::getNextMonth($currentDate) : \App\Calendar\CalendarView::getNextWeek($currentDate)]) }}"
+        >
             <span class="material-symbols-outlined">keyboard_double_arrow_right</span>
         </a>
     </span>

--- a/resources/views/schedule/scheduleEdit.blade.php
+++ b/resources/views/schedule/scheduleEdit.blade.php
@@ -44,14 +44,14 @@
                             </div>
                             <div class="schedule-form__datetime-datetime">
                                 <div class="schedule-form__datetime-datetime-start">
-                                    <input class="schedule-form__start-date-input schedule-form__date-input" type="date" name="start_date" value="{{ old('start_date', $date ?? $schedule->start_date ?? '') }}" required>
+                                    <input class="schedule-form__start-date-input schedule-form__date-input" type="date" name="start_date" value="{{ old('start_date', $currentDate ?? $schedule->start_date ?? '') }}" required>
                                     <div class="schedule-form__start-time-wrapper">
                                         <input class="schedule-form__start-time-input schedule-form__time-input" type="time" name="start_time" value="{{ old('start_time', $schedule->start_time ?? '') }}">
                                     </div>
                                 </div>
                                 <div>～</div>
                                 <div class="schedule-form__datetime-datetime-end">
-                                    <input class="schedule-form__end-date-input schedule-form__date-input" type="date" name="end_date" value="{{ old('end_date', $date ?? $schedule->end_date ?? '') }}" required>
+                                    <input class="schedule-form__end-date-input schedule-form__date-input" type="date" name="end_date" value="{{ old('end_date', $currentDate ?? $schedule->end_date ?? '') }}" required>
                                     <div class="schedule-form__end-time-wrapper">
                                         <input class="schedule-form__end-time-input schedule-form__time-input" type="time" name="end_time" value="{{ old('end_time', $schedule->end_time ?? '') }}">
                                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,12 +20,11 @@ Route::middleware('auth')->group(function () {
 });
 
 // カレンダー
-Route::get('calendar/{type?}/{currentDate?}', [CalendarController::class, 'show'])
+Route::get('calendar/{type?}', [CalendarController::class, 'show'])
     ->middleware('auth')
     ->name('calendar.view')
     ->where([
-        'type' => 'month|week|day',
-        'currentDate' => '\d{4}-\d{2}-\d{2}' //Y-m-d
+        'type' => 'month|week|day'
     ]);
 
 // スケジュール

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,16 +28,16 @@ Route::get('calendar/{type?}', [CalendarController::class, 'show'])
     ]);
 
 // スケジュール
+//ID無し用
+Route::middleware('auth')->prefix('/schedule')->name('schedule.')->group(function() {
+    Route::get('create', [ScheduleController::class, 'create'])->name('create');
+    Route::post('store', [ScheduleController::class, 'store'])->name('store');
+});
 // ID必須用
 Route::middleware('auth')->prefix('/schedule/{id}')->name('schedule.')->group(function() {
     Route::get('', [ScheduleController::class, 'show'])->name('show');
     Route::get('edit', [ScheduleController::class, 'edit'])->name('edit');
     Route::post('update', [ScheduleController::class, 'update'])->name('update');
-});
-//ID無し用
-Route::middleware('auth')->prefix('/schedule')->name('schedule.')->group(function() {
-    Route::get('create/{date?}', [ScheduleController::class, 'create'])->name('create');
-    Route::post('store', [ScheduleController::class, 'store'])->name('store');
 });
 
 


### PR DESCRIPTION
## 概要
スケジュールカレンダーにおけるルーティングの構成を見直し、柔軟性と可読性の向上を目的として以下の修正を行った


## 変更内容

- 'currentDate'をルートパラメータからクエリパラメータに変更
- 不正なルート解釈を避けるため、パラメータのあいまいな解釈を排除
- Controller、Blade等側でもクエリパラメータに対応するよう修正

## 修正の背景

ルートパラメータを多用して処理をしていると、パラメータの解釈が曖昧になるケースがあり、意図しない画面遷移が発生することがあった 

